### PR TITLE
Add skip-deploy logic for docs-only changes

### DIFF
--- a/.github/workflows/fly-staging.yml
+++ b/.github/workflows/fly-staging.yml
@@ -11,10 +11,39 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
+      - name: Skip deploy if only docs were changed
+        id: check_docs_only
+        run: |
+            CHANGED_FILES=$(git diff --name-only ${{ github.event.before }} ${{ github.sha }})
+            echo "Changed files:"
+            echo "$CHANGED_FILES"
+
+            ONLY_DOCS=true
+            for file in $CHANGED_FILES; do
+            if [[ "$file" != *.md && "$file" != dev-notes/* ]]; then
+             ONLY_DOCS=false
+             break
+            fi
+            done
+
+            echo "only_docs=$ONLY_DOCS" >> $GITHUB_OUTPUT
+
+      - name: Cancel deploy if only docs changed
+        if: steps.check_docs_only.outputs.only_docs == 'true'
+        run: |
+          echo "Skipping deploy: only docs were changed."
+          exit 0
+
       - uses: superfly/flyctl-actions/setup-flyctl@master
 
       - name: Deploy to Fly.io
         run: flyctl deploy --remote-only -c fly.staging.toml
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN_STAGING }}
+
+      - name: Wait for Fly VM to become healthy
+        run: flyctl wait --app akluma-staging --timeout 60
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN_STAGING }}
 


### PR DESCRIPTION
This PR adds logic to the Fly staging GitHub Actions workflow to skip deployments when only markdown or dev-notes/ files are changed.