### PR TITLE
Implement admin alert email for excessive failed reminder attempts

### DIFF
--- a/app/Mail/AdminRetryAlert.php
+++ b/app/Mail/AdminRetryAlert.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Mail;
+
+use App\Models\ScheduledSaving;
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Queue\SerializesModels;
+
+class AdminRetryAlert extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    public $saving;
+    public $attemptCount;
+
+    /**
+     * Create a new message instance.
+     */
+    public function __construct(ScheduledSaving $saving, int $attemptCount)
+    {
+        $this->saving = $saving;
+        $this->attemptCount = $attemptCount;
+    }
+
+    /**
+     * Build the message.
+     */
+    public function build()
+    {
+        return $this
+            ->subject("🚨 {$this->attemptCount} failed email attempts for saving ID {$this->saving->id}")
+            ->markdown('emails.admin.retry-alert');
+    }
+}

--- a/resources/views/emails/admin/retry-alert.blade.php
+++ b/resources/views/emails/admin/retry-alert.blade.php
@@ -1,0 +1,14 @@
+@component('mail::message')
+    # Admin Retry Alert
+
+    Saving ID **{{ $saving->id }}** has failed to send an email **{{ $attemptCount }} times**.
+
+    - Piggy Bank: **{{ $saving->piggyBank->name }}**
+    - User: **{{ $saving->piggyBank->user->email }}**
+    - Saving Date: **{{ $saving->saving_date }}**
+
+    You may want to investigate this saving.
+
+    Thanks,<br>
+    Akluma System
+@endcomponent


### PR DESCRIPTION
- Refactored RetryFailedReminders.php to remove arbitrary retry cap and allow unlimited retries.
- Added email alert via AdminRetryAlert Mailable when a saving exceeds 100 failed email attempts.
- Created resources/views/emails/admin/retry-alert.blade.php with detailed info on the failing saving.
- Updated AdminRetryAlert.php to accept the ScheduledSaving model and attempt count, and use the markdown view.
- The system now continues retrying without skipping, but notifies admin when reminders appear stuck.