### PR TITLE
Fix: Reset notification_statuses when piggy bank is resumed (Issue #286)

### DIFF
--- a/app/Http/Controllers/ScheduledSavingController.php
+++ b/app/Http/Controllers/ScheduledSavingController.php
@@ -254,9 +254,19 @@ class ScheduledSavingController extends Controller
 
                 // \Log::info("Working date calculated for saving #{$saving->saving_number}: {$workingDate}");
 
-                // Update with the new date
-                $saving->update(['saving_date' => $workingDate]);
-                // \Log::info("Saved new date: {$workingDate}");
+                // Update date and reset notification tracking so reminders are sent for the new date
+                $saving->saving_date = $workingDate;
+                $saving->notification_statuses = null;
+                $saving->notification_attempts = null;
+                $saving->save();
+                // \Log::info("Saving #{$saving->saving_number} updated", [
+                //     'old_date' => $saving->saving_date->format('Y-m-d'),
+                //     'new_date' => $workingDate->format('Y-m-d'),
+                //     'old_notification_statuses' => $saving->notification_statuses,
+                //     'old_notification_attempts' => $saving->notification_attempts,
+                //     'new_notification_statuses' => null,
+                //     'new_notification_attempts' => null,
+                // ]);
             }
 
             $scheduleUpdated = true;


### PR DESCRIPTION
## Summary
  - Fixes a bug where saving reminders were not sent after a piggy bank was paused and resumed
  - When resuming, saving dates are recalculated but `notification_statuses` was not reset
  - This caused the system to think reminders were "already sent" for the new dates

  ## Root Cause
  In `resumePiggyBank()`, when saving dates were recalculated, only `saving_date` was updated. The
  `notification_statuses` (which tracks if reminders were sent) retained the old "sent" status from the
  previous date, causing reminders to be skipped for the new dates.

  ## Fix
  Reset `notification_statuses` and `notification_attempts` to `null` when saving dates are recalculated
  during resume. This ensures reminders are sent for the new dates.

  ## Testing
  1. Created piggy bank with daily frequency
  2. Simulated reminder sent (notification_statuses.email.sent = true)
  3. Paused → Resumed piggy bank
  4. Verified notification_statuses was reset to null
  5. Confirmed reminder command no longer skips the saving
