### PR TITLE
Fix PHP 8.4 deployment by updating build args in fly.toml files

### DIFF
--- a/.github/workflows/fly-staging.yml
+++ b/.github/workflows/fly-staging.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Deploy to Fly.io
         if: steps.check_files.outputs.only_docs != 'true'
-        run: flyctl deploy --remote-only -c fly.staging.toml --no-cache
+        run: flyctl deploy --remote-only -c fly.staging.toml
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN_STAGING }}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax = docker/dockerfile:experimental
 
-ARG PHP_VERSION=8.4
+ARG PHP_VERSION
 ARG NODE_VERSION=18
 FROM ubuntu:22.04 as base
 LABEL fly_launch_runtime="laravel"

--- a/fly.production.toml
+++ b/fly.production.toml
@@ -10,7 +10,7 @@ console_command = 'php /var/www/html/artisan tinker'
 [build]
   [build.args]
     NODE_VERSION = '18'
-    PHP_VERSION = '8.2'
+    PHP_VERSION = '8.4'
 
 [env]
   APP_ENV = 'production'

--- a/fly.staging.toml
+++ b/fly.staging.toml
@@ -10,7 +10,7 @@ console_command = 'php /var/www/html/artisan tinker'
 [build]
   [build.args]
     NODE_VERSION = '18'
-    PHP_VERSION = '8.2'
+    PHP_VERSION = '8.4'
 
 [env]
   APP_ENV = 'staging'


### PR DESCRIPTION
  - Update PHP_VERSION to 8.4 in fly.staging.toml and fly.production.toml
  - Remove default PHP_VERSION from Dockerfile (fly.toml is now single source of truth)
  - Revert --no-cache from staging workflow