### PR TITLE
Fallback for null Google name and reposition Google info banner on profile

### DIFF
--- a/app/Http/Controllers/Auth/SocialiteController.php
+++ b/app/Http/Controllers/Auth/SocialiteController.php
@@ -85,7 +85,7 @@ class SocialiteController extends Controller
         $timezone = session('google_timezone', 'UTC');
 
         $user = User::forceCreate([
-            'name' => $googleUser->getName(),
+            'name' => $googleUser->getName() ?: explode('@', $googleUser->getEmail())[0],
             'email' => $googleUser->getEmail(),
             'password' => null,
             'google_id' => $googleUser->getId(),

--- a/resources/views/profile/edit.blade.php
+++ b/resources/views/profile/edit.blade.php
@@ -7,19 +7,6 @@
 
     <div class="py-4 px-4">
         <div class="max-w-7xl mx-auto sm:px-6 lg:px-8 space-y-6">
-            @if (auth()->user()->google_id)
-                <div class="p-4 sm:p-8 bg-white shadow-sm rounded-lg">
-                    <div class="max-w-xl flex items-center gap-3">
-                        <x-google-icon class="w-5 h-5 shrink-0" />
-                        <p class="text-sm text-gray-600">
-                            {{ __('Your account is connected to Google.') }}
-                            @if (! auth()->user()->hasPassword())
-                                {{ __('You can set a password anytime using the "Forgot your password?" link on the login page.') }}
-                            @endif
-                        </p>
-                    </div>
-                </div>
-            @endif
 
             <div class="p-4 sm:p-8 bg-white shadow-sm rounded-lg">
                 <div class="max-w-xl">
@@ -39,6 +26,20 @@
                         @include('profile.partials.update-password-form')
                     </div>
                 </div>
+            @endif
+
+            @if (auth()->user()->google_id)
+            <div class="p-4 sm:p-8 bg-white shadow-sm rounded-lg">
+                <div class="max-w-xl flex items-center gap-3">
+                    <x-google-icon class="w-5 h-5 shrink-0" />
+                    <p class="text-sm text-gray-600">
+                        {{ __('Your account is connected to Google.') }}
+                        @if (! auth()->user()->hasPassword())
+                            {{ __('You can set a password anytime using the "Forgot your password?" link on the login page.') }}
+                        @endif
+                    </p>
+                </div>
+            </div>
             @endif
 
             <div class="p-4 sm:p-8 bg-white shadow-sm rounded-lg">


### PR DESCRIPTION
- Use email prefix as name fallback when Google doesn't provide one
- Move Google account info banner below password section for better visual flow