### PR TITLE
Fix: prevent pausing classic piggy banks

### DIFF
--- a/app/Http/Controllers/ScheduledSavingController.php
+++ b/app/Http/Controllers/ScheduledSavingController.php
@@ -164,6 +164,10 @@ class ScheduledSavingController extends Controller
     {
         $piggyBank = PiggyBank::findOrFail($piggy_id);
 
+        if ($piggyBank->isClassic()) {
+            return response()->json(['error' => 'Classic piggy banks cannot be paused.'], 400);
+        }
+
         // Ensure we do not pause a completed or cancelled piggy bank
         if (in_array($piggyBank->status, ['done', 'cancelled'])) {
             return response()->json(['error' => 'Cannot pause a completed or cancelled piggy bank.'], 400);

--- a/tests/Feature/ClassicPiggyBankTest.php
+++ b/tests/Feature/ClassicPiggyBankTest.php
@@ -421,6 +421,18 @@ it('prevents another user from changing status', function () {
         ->assertForbidden();
 });
 
+it('prevents pausing a classic piggy bank', function () {
+    app()->setLocale('en');
+    $user = User::factory()->create();
+    $piggyBank = PiggyBank::factory()->for($user)->classic()->create();
+
+    actingAs($user)
+        ->patchJson("/en/piggy-banks/$piggyBank->id/pause")
+        ->assertStatus(400);
+
+    expect($piggyBank->fresh()->status)->toBe('active');
+});
+
 // ──────────────────────────────────────────────────
 // Financial Summary Authorization
 // ──────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Adds an `isClassic()` guard to the `pausePiggyBank` endpoint in `ScheduledSavingController`, preventing classic piggy banks from being paused via direct API calls
- Classic piggy banks don't support the `paused` status and have no resume UI, so allowing this would leave users stuck

## Test plan
- [x] New test: `it prevents pausing a classic piggy bank`
- [x] All 38 ClassicPiggyBankTest tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)