### PR TITLE
Deploy to staging: host-native Vite convention + re-enable Claude review

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   claude-review:
     # set this to true to enable claude code PR reviews
-    if: false
+    if: true
     # Optional: Filter by PR author
     # if: |
     #   github.event.pull_request.user.login == 'external-contributor' ||

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,10 +15,12 @@ Instead, use one of these approaches:
 
 **Development:**
 - `composer dev` - Start all development services (server, queue, logs, vite)
-- `./vendor/bin/sail up -d` - Start Docker environment
+- `./vendor/bin/sail up -d` - Start Docker environment (PHP, MySQL)
 - `./vendor/bin/sail artisan serve` - Start Laravel server
-- `npm run dev` - Start Vite development server
-- `npm run build` - Build assets for production
+- `npm run dev` - Start Vite development server (runs on host, not in Docker)
+- `npm run build` - Build assets for production (runs on host, not in Docker)
+
+**Important:** Never prefix Node/npm commands with `sail`. Node runs on the host because `node_modules/` contains platform-specific native binaries (Rollup, esbuild) that are incompatible across macOS and Linux.
 
 **Testing:**
 - `./vendor/bin/sail pest` - Run all tests using Pest
@@ -31,6 +33,10 @@ Instead, use one of these approaches:
 **Database:**
 - `./vendor/bin/sail artisan migrate` - Run migrations
 - `./vendor/bin/sail artisan migrate:fresh --seed` - Fresh migration with seeders
+
+## Project Structure Notes
+
+- `dev-notes/` is gitignored. It contains local development documentation, implementation plans, and troubleshooting guides. Changes to files in this directory will not appear in `git status` or diffs and cannot be committed.
 
 ## Architecture
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,6 @@ services:
             - 'host.docker.internal:host-gateway'
         ports:
             - '${APP_PORT:-80}:80'
-            - '${VITE_PORT:-5173}:${VITE_PORT:-5173}'
         environment:
             WWWUSER: '${WWWUSER}'
             LARAVEL_SAIL: 1


### PR DESCRIPTION
## Summary
- Clarify in CLAUDE.md that Node/npm runs on host, not in Docker
- Document that `dev-notes/` is gitignored
- Remove unused VITE_PORT mapping from docker-compose.yml
- Re-enable Claude Code PR review workflow

## Test plan
- [x] `npm run dev` works on host
- [x] `sail up -d` serves the app correctly
- [x] HMR works with Vite running on host