### PR TITLE
fix: upgrade phpseclib/phpseclib 3.0.49 → 3.0.50 (CVE-2026-32935)

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4158,16 +4158,16 @@
         },
         {
             "name": "phpseclib/phpseclib",
-            "version": "3.0.49",
+            "version": "3.0.50",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpseclib/phpseclib.git",
-                "reference": "6233a1e12584754e6b5daa69fe1289b47775c1b9"
+                "reference": "aa6ad8321ed103dc3624fb600a25b66ebf78ec7b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/6233a1e12584754e6b5daa69fe1289b47775c1b9",
-                "reference": "6233a1e12584754e6b5daa69fe1289b47775c1b9",
+                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/aa6ad8321ed103dc3624fb600a25b66ebf78ec7b",
+                "reference": "aa6ad8321ed103dc3624fb600a25b66ebf78ec7b",
                 "shasum": ""
             },
             "require": {
@@ -4248,7 +4248,7 @@
             ],
             "support": {
                 "issues": "https://github.com/phpseclib/phpseclib/issues",
-                "source": "https://github.com/phpseclib/phpseclib/tree/3.0.49"
+                "source": "https://github.com/phpseclib/phpseclib/tree/3.0.50"
             },
             "funding": [
                 {
@@ -4264,7 +4264,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-27T09:17:28+00:00"
+            "time": "2026-03-19T02:57:58+00:00"
         },
         {
             "name": "psr/cache",


### PR DESCRIPTION
## Summary

- Upgrades `phpseclib/phpseclib` from 3.0.49 to 3.0.50 to fix **CVE-2026-32935** (high-severity padding oracle timing attack in AES-CBC unpadding)
- Transitive dependency via `laravel/socialite` — patch bump, no API changes
- Google login tests pass

## References

- Closes #341
- Dependabot alert: https://github.com/Ubeydu/akluma-your-smart-piggy-bank/security/dependabot/30
- Advisory: GHSA-94g3-g5v7-q4jg

## Test plan

- [x] `./vendor/bin/sail pest tests/Feature/Auth/GoogleLoginTest.php` — passes
- [ ] Verify Dependabot alert clears after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)