### PR TITLE
fix: check real MySQL readiness in parallel-session.sh

### DIFF
--- a/scripts/parallel-session.sh
+++ b/scripts/parallel-session.sh
@@ -187,7 +187,7 @@ cmd_create() {
             echo "Warning: Timed out after 90 seconds. You may need to seed manually."
             break
         fi
-        if (cd "$wt_dir" && docker compose exec -T mysql mysqladmin ping -p"$db_password" --silent &>/dev/null); then
+        if (cd "$wt_dir" && docker compose exec -T mysql mysql -u sail -p"$db_password" -e "SELECT 1" &>/dev/null); then
             break
         fi
         sleep 1


### PR DESCRIPTION
## Summary
- The readiness check in `scripts/parallel-session.sh` used `mysqladmin ping` inside the mysql container, which connects via Unix socket and returns success before the MySQL init scripts finish creating the `sail` user and `akluma` database. The seed step then ran too early and failed with `SQLSTATE[HY000] [2002] Connection refused`.
- Replace the ping with an authenticated `SELECT 1` as the `sail` user, which only succeeds once init is fully done.
- Net change: one line.

## Test plan
- [x] Destroy an existing worktree, recreate it with the fixed script, confirm migrations + seed run cleanly on a fresh volume without manual retry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)