### PR TITLE
fix: force TCP in MySQL readiness check in parallel-session.sh

### DIFF
--- a/scripts/parallel-session.sh
+++ b/scripts/parallel-session.sh
@@ -187,7 +187,7 @@ cmd_create() {
             echo "Warning: Timed out after 90 seconds. You may need to seed manually."
             break
         fi
-        if (cd "$wt_dir" && docker compose exec -T mysql mysql -u sail -p"$db_password" -e "SELECT 1" &>/dev/null); then
+        if (cd "$wt_dir" && docker compose exec -T mysql mysqladmin ping -h 127.0.0.1 -u sail -p"$db_password" --silent &>/dev/null); then
             break
         fi
         sleep 1


### PR DESCRIPTION
## Summary
- Follow-up to #382, which was incomplete.
- Previous check ran `mysql -u sail -p... -e "SELECT 1"` inside the mysql container. The `mysql` CLI defaults to Unix socket, which stays available during the MySQL 8.x entrypoint's init phase (mysqld runs temporarily with `--skip-networking` to seed users and DBs). The check passed while TCP was still closed, and the follow-up `migrate:fresh` — which connects over TCP from the laravel.test container to `mysql:3306` — hit `[2002] Connection refused`.
- Switch to `mysqladmin ping -h 127.0.0.1 -u sail -p... --silent`, which forces TCP and only succeeds after the final mysqld start.

## Test plan
- [ ] Destroy + recreate a worktree on a fresh volume with this change; confirm migrations + seed run cleanly without any manual retry. (Not done in the PR author's environment because two active worktrees are in use — will verify on first worktree creation after merge.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)