### PR TITLE
chore: pin package name in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+    "name": "akluma2",
     "private": true,
     "type": "module",
     "scripts": {


### PR DESCRIPTION
## Summary
- `package.json` had no top-level `name` field, so `npm install` fell back to deriving the name from the working directory.
- In every parallel worktree this produced a dirty `package-lock.json` diff — top-level `name` got rewritten to the worktree directory name, and `packages[""].name` was dropped.
- Setting `"name": "akluma2"` explicitly pins the identity so any directory produces an identical lockfile.

## Test plan
- [x] Confirm the committed `package-lock.json` already has `"name": "akluma2"` at both the top level and under `packages[""]`, so no lockfile regeneration is needed.
- [ ] After merge: in a fresh worktree, run `npm install` and confirm `git diff package-lock.json` is empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)