### PR TITLE
fix: set SESSION_LIFETIME=43200 in fly.toml to fix remember me checkbox

### DIFF
--- a/fly.production.toml
+++ b/fly.production.toml
@@ -18,6 +18,7 @@ console_command = 'php /var/www/html/artisan tinker'
   LOG_LEVEL = 'info'
   LOG_STDERR_FORMATTER = 'Monolog\Formatter\JsonFormatter'
   SESSION_DRIVER = 'cookie'
+  SESSION_LIFETIME = '43200'
   SESSION_SECURE_COOKIE = 'true'
   REMINDERS_TEST_MODE = "false"
 

--- a/fly.staging.toml
+++ b/fly.staging.toml
@@ -18,6 +18,7 @@ console_command = 'php /var/www/html/artisan tinker'
   LOG_LEVEL = 'info'
   LOG_STDERR_FORMATTER = 'Monolog\Formatter\JsonFormatter'
   SESSION_DRIVER = 'cookie'
+  SESSION_LIFETIME = '43200'
   SESSION_SECURE_COOKIE = true
   REMINDERS_TEST_MODE = "false"
 

--- a/tests/Feature/Auth/AuthenticationTest.php
+++ b/tests/Feature/Auth/AuthenticationTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Models\User;
+use Illuminate\Support\Facades\Auth;
 
 test('login screen can be rendered', function () {
     $response = $this->get('/login');
@@ -29,6 +30,31 @@ test('users can not authenticate with invalid password', function () {
     ]);
 
     $this->assertGuest();
+});
+
+it('sets remember me cookie when remember checkbox is checked', function () {
+    $user = User::factory()->create();
+
+    $response = $this->post('/en/login', [
+        'email' => $user->email,
+        'password' => 'password',
+        'remember' => '1',
+    ]);
+
+    $this->assertAuthenticated();
+    $response->assertCookie(Auth::guard()->getRecallerName());
+});
+
+it('does not set remember me cookie when remember checkbox is unchecked', function () {
+    $user = User::factory()->create();
+
+    $response = $this->post('/en/login', [
+        'email' => $user->email,
+        'password' => 'password',
+    ]);
+
+    $this->assertAuthenticated();
+    $response->assertCookieMissing(Auth::guard()->getRecallerName());
 });
 
 test('users can logout', function () {


### PR DESCRIPTION
Production sessions defaulted to 120 minutes, making remember me have no
visible impact. Sessions now last 30 days; with remember me checked, the
5-year cookie provides permanent login. Adds two tests for cookie behavior.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
