### PR TITLE
Deploy to staging: remove MVP copy from Register page

### DIFF
--- a/lang/fr.json
+++ b/lang/fr.json
@@ -157,7 +157,6 @@
   "Minimum 8 characters.": "Minimum 8 caractères.",
   "You have reached the maximum limit of :limit active or paused piggy banks. Please complete or cancel some existing piggy banks before creating a new one.": "Vous avez atteint la limite maximale de :limit tirelires actives ou mises en pause. Veuillez terminer ou annuler certaines tirelires existantes avant d'en créer une nouvelle.",
   "Coming Soon ✨": "Bientôt disponible ✨",
-  "Currently, our website is completely free.<br><br>We're launching an MVP (Minimum Viable Product) first to gauge how useful this tool is for our users. If we see strong engagement, we may introduce premium features later.<br><br>But for now—enjoy, save money, and help us grow!": "Pour l'instant, notre site est entièrement gratuit.<br><br>Nous lançons d'abord un MVP (Produit Minimum Viable) afin de mesurer l'intérêt réel de cet outil pour nos utilisateurs. Si l'intérêt est élevé, nous pourrions introduire plus tard des fonctionnalités premium.<br><br>Mais pour le moment—profitez-en, économisez et aidez-nous à grandir !",
   "founder": "fondateur",
   "step1_name_placeholder": "ex. frais scolaires, Samsung Galaxy S25, ce super gadget pour la cuisine ou capital pour lancer votre entreprise ...",
   "step1_link_placeholder": "ex. https://www.e.leclerc/fp/samsung-galaxy-s25",

--- a/lang/tr.json
+++ b/lang/tr.json
@@ -260,7 +260,6 @@
   "piggybank.empty_state.button_text": "Kumbaranı Oluştur",
   "Minimum 8 characters.": "En az 8 karakter.",
   "You have reached the maximum limit of :limit active or paused piggy banks. Please complete or cancel some existing piggy banks before creating a new one.": "Maksimum :limit aktif veya duraklatılmış kumbara sınırına ulaştın. Yeni bir kumbara oluşturmadan önce mevcut kumbaralarından bazılarını tamamla veya iptal et.",
-  "Currently, our website is completely free.<br><br>We're launching an MVP (Minimum Viable Product) first to gauge how useful this tool is for our users. If we see strong engagement, we may introduce premium features later.<br><br>But for now—enjoy, save money, and help us grow!": "Şu anda web sitemiz tamamen ücretsiz.<br><br>Bu aracın kullanıcılarımız için ne kadar faydalı olduğunu görmek adına önce bir MVP (asgari çalışır ürün) yayınlıyoruz. Eğer yoğun bir ilgi görürsek, daha sonra ücretli özellikler ekleyebiliriz.<br><br>Fakat şimdilik—keyfini çıkar, para biriktir ve büyümemize yardımcı ol!",
   "founder": "kurucu",
   "step1_name_placeholder": "örn. okul taksidi, Samsung Galaxy S25, mutfağa almak istediğin o harika cihaz, ya da iş kurmak için sermaye ...",
   "step1_link_placeholder": "örn. https://www.trendyol.com/samsung/galaxy-s25-256-gb-lacivert-cep-telefonu",

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -1,19 +1,6 @@
 @section('title', __('Register') . ' - ' . __('app_name'))
 
 <x-guest-layout>
-    <div class="mb-6 p-4 bg-indigo-50 border-l-4 border-indigo-400 text-indigo-700 rounded-sm">
-        <p class="text-sm">
-            {!! __('Currently, our website is completely free.<br><br>We\'re launching an MVP (Minimum Viable Product) first to gauge how useful this tool is for our users. If we see strong engagement, we may introduce premium features later.<br><br>But for now—enjoy, save money, and help us grow!') !!}
-        </p>
-
-        <p class="mt-4 text-sm text-indigo-600">
-            &mdash;
-            <a href="https://www.linkedin.com/in/ubeydullah-kele%C5%9F-2221a915/" target="_blank" rel="noopener noreferrer" class="text-indigo-700 hover:underline font-medium">
-                Ubeydullah Keleş, {{ __('founder') }}
-            </a>
-        </p>
-    </div>
-
     <!-- Google Sign-In -->
     <a href="{{ route('auth.google.redirect') }}"
        id="google-register-btn"


### PR DESCRIPTION
Deletes the indigo MVP/founder block from auth/register.blade.php and
removes the orphan translation keys from lang/tr.json and lang/fr.json.

The About page already conveys the equivalent "currently free" story via
about.who_text_2 and carries the LinkedIn link in its Contact section, so
no content needs to be added to About.

Closes #394

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
